### PR TITLE
Update slicer cli web plugin location

### DIFF
--- a/histomicsui.Dockerfile
+++ b/histomicsui.Dockerfile
@@ -35,7 +35,7 @@ RUN cd /opt && \
     git clone https://github.com/girder/girder && \
     cd /opt/girder && \
     git checkout v4-integration && \
-    cd ./plugins/slicer_cli_web/girder_slicer_cli_web/web_client && npm i && npm run build && cd ../.. && \
+    cd ./plugins/slicer_cli_web/slicer_cli_web/web_client && npm i && npm run build && cd ../.. && \
     pip install --no-cache-dir -e .[girder]
 
 # TODO this can be removed once a fixed large-image-source-zarr is published


### PR DESCRIPTION
[This PR in the girder repository](https://github.com/girder/girder/pull/3662) renamed the `girder_slicer_cli_web/` directory to just `slicer_cli_web/`. This updates the `histomicsui.Dockerfile` to install the slicer plugin from that location. It looks like `worker.Dockerfile` already installs from the correct place.