### PR TITLE
Update worker command and slicer build location

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - assetstore:/assetstore
       - ./girder_worker/girder_worker:/opt/girder_worker/girder_worker
       - ./girder/plugins/slicer_cli_web/girder_slicer_cli_web:/opt/girder/plugins/slicer_cli_web/girder_slicer_cli_web
+      - ./girder/plugins/worker/girder_plugin_worker:/opt/girder/plugins/worker/girder_plugin_worker
       - ./large_image/sources/gdal/large_image_source_gdal:/opt/large_image/sources/gdal/large_image_source_gdal
       - ./large_image/sources/ometiff/large_image_source_ometiff:/opt/large_image/sources/ometiff/large_image_source_ometiff
       - ./large_image/sources/tiff/large_image_source_tiff:/opt/large_image/sources/tiff/large_image_source_tiff
@@ -58,13 +59,16 @@ services:
   worker:
     environment:
       - GIRDER_WORKER_BROKER=amqp://rabbitmq:5672
-    command: girder-worker
+    command: celery -A girder_worker.app worker
     volumes:
       - ./HistomicsUI/histomicsui:/opt/histomicsui/histomicsui
+      - /var/run/docker.sock:/var/run/docker.sock
     build:
       context: .
       dockerfile: ./worker.Dockerfile
     platform: linux/amd64
+    depends_on :
+      - rabbitmq
 
 
 volumes:

--- a/init.sh
+++ b/init.sh
@@ -11,7 +11,7 @@ pushd girder_worker/girder_worker/girder_plugin/web_client
 npm i && npm run build
 popd
 
-pushd girder/plugins/slicer_cli_web/girder_slicer_cli_web/web_client
+pushd girder/plugins/slicer_cli_web/slicer_cli_web/web_client
 npm i && npm run build
 popd
 


### PR DESCRIPTION
Recently tried using this repository to bootstrap some new Histomics development and noticed a couple of issues getting up and running.

First, the command `girder_worker` no longer exists and so I've changed the docker compose service to just invoke `celery` directly instead.

Also, the slicer cli plugin directory, was renamed (`girder_slicer_cli_web` -> `slicer_cli_web`), so the `init.sh` script was failing when trying to build, as that script has not updated with the new location.